### PR TITLE
chore: add 'devcontainer.json'

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM manjarolinux/base:latest
+
+RUN pacman -Syu --noconfirm
+RUN pacman -S --noconfirm vim git python python-pip nodejs npm

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+	"name": "full-stack",
+	"build": {
+		"dockerfile": "Dockerfile",
+	},
+	"runArgs": [
+		"--name",
+		"full-stack"
+	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"redhat.vscode-yaml"
+			]
+		}
+	}
+}


### PR DESCRIPTION
- This pull request provides a development container based on [Manjaro Linux](https://manjaro.org). 
- The container image is configured with required development environment, such as `python`, `nodejs`, and `vim`.
- The container image works on both `linux/amd64` and `linux/arm64`.
