### PR TITLE
chore: update 'devcontainer.json'

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,1 @@
-FROM manjarolinux/base:latest
-
-RUN pacman -Syu --noconfirm
-RUN pacman -S --noconfirm vim git python python-pip nodejs npm
+FROM ubuntu:mantic

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "full-stack",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "Dockerfile"
 	},
 	"runArgs": [
 		"--name",


### PR DESCRIPTION
- Replace `manjarolinux/base:latest` with `ubuntu:mantic`: It turns out that `mongodb` has been removed from the Arch Linux official repositories due to its re-licensing issues.