### PR TITLE
fix: add a proxy to allow cookie been passed between front and back

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,4 +1,5 @@
 {
+  "proxy": "http://127.0.0.1:5000",
   "name": "frontend",
   "version": "0.1.0",
   "private": true,


### PR DESCRIPTION
Before this change, cookie can not be passed between frontend and backend even use flask login; after this change, we use a proxy to make frontend and backend be served from the same host and port for cookies to work.